### PR TITLE
Badge to show you’re free of known vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # node-tryfer: A Node Zipkin Tracer Library
 
 [![Build Status](https://secure.travis-ci.org/tryfer/node-tryfer.png?branch=master)](http://travis-ci.org/tryfer/node-tryfer)
+[![Known Vulnerabilities](https://snyk.io/test/github/tryfer/node-tryfer/061ed05a172b70fe04154214d1519be9246ecf5a/badge.svg)](https://snyk.io/test/github/tryfer/node-tryfer/061ed05a172b70fe04154214d1519be9246ecf5a)
 
 Zipkin is a Distributed Tracing system, tryfer is a Python/Twisted client library for Zipkin, and node-tryfer is a port of tryfer.
 


### PR DESCRIPTION
node-tryfer has no vulnerabilities, which is awesome! 

This PR adds a badge that shows you’re free of known vulnerabilities. Note that the badge works off the latest master branch.

Adding the badge will show others that you care about security, and that they should care, too. 
(It will also help to spread the word about Snyk, which would benefit us a lot!). 
 
Check our [documentation](https://snyk.io/docs/badges/#github-badge) if you’d like to know more about our badges. 

Stay secure, 
The Snyk team